### PR TITLE
Fixes for postgresql roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,20 @@
 # Changelog
 
+## 1.3.0 - 2025-05-10
+
+* New `postgresql` and `postgresql_objects` roles from the Galaxy project
+  (https://galaxy.ansible.com/ui/standalone/namespaces/2450/).
+* Updated `ntp` and `libvirt_host` roles.
+* Various small fixes for `tinc` role.
+
 ## 1.2.0 - 2024-11-01
 
-New release adding tinc role.
+New release adding `tinc` role.
 
 ## 1.1.0 - 2024-10-23
 
-New release adding libvirt-host, libvirt-vm, and ntp roles.
+New release adding `libvirt_host`, `libvirt_vm`, and `ntp` roles.
 
 ## 1.0.0 - 2024-09-11
 
-Initial release with resolv role.
+Initial release with `resolv` role.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,3 +13,7 @@ readme: README.md
 license_file: LICENSE
 
 repository: https://github.com/Tina-pm/tina_pm.third_party.git
+
+dependencies:
+  community.libvirt: '>=1.3.0'
+  community.postgresql: '>=3.3.0'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: tina_pm
 name: third_party
-version: 1.2.0
+version: 1.3.0
 
 authors:
   - Adeodato Simó

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+libvirt-python

--- a/roles/postgresql/README.md
+++ b/roles/postgresql/README.md
@@ -89,6 +89,8 @@ Role Variables
   that Ansible is using on the remote side. This allows for the use of the `postgresql_*` Ansible modules (perhaps via
   [galaxyproject.postgresql_objects][postgresql_objects]), which depend on psycopg2. Defaults to `true`.
 
+- `postgresql_install_extra`: List of other packages to install, for example database extensions and the like.
+
 ### Backups ###
 
 This role can deploy and schedule the configuration and scripts to maintain Postgresql [PITR][postgresql_pitr] backups.

--- a/roles/postgresql/defaults/main.yml
+++ b/roles/postgresql/defaults/main.yml
@@ -9,6 +9,7 @@ postgresql_default_version: 15
 postgresql_user_name: postgres
 
 postgresql_install_psycopg2: true
+postgresql_install_extra: []
 
 # Point-In-Time Recovery (PITR) backup options
 #   https://www.postgresql.org/docs/current/continuous-archiving.html

--- a/roles/postgresql/tasks/debian.yml
+++ b/roles/postgresql/tasks/debian.yml
@@ -38,11 +38,13 @@
   when: postgresql_version is not defined
   register: __postgresql_version_query_result
   changed_when: false
+  check_mode: false
 
 - name: Set version fact
   set_fact:
     postgresql_version: "{{ __postgresql_version_query_result.stdout.split('+') | first }}"
   when: postgresql_version is not defined
+  check_mode: false
 
 - name: Install psycopg2
   apt:

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -29,6 +29,12 @@
 - include_tasks: redhat.yml
   when: ansible_os_family == "RedHat"
 
+- name: Install extra packages
+  package:
+    name: "{{ item }}"
+    state: present
+  loop: "{{ postgresql_install_extra }}"
+
 - name: Create conf.d
   file:
     path: "{{ postgresql_conf_dir }}/conf.d"

--- a/roles/postgresql_objects/README.md
+++ b/roles/postgresql_objects/README.md
@@ -6,8 +6,8 @@ PostgreSQL Objects
 
 PostgreSQL Objects is an [Ansible][ansible] role for managing PostgreSQL users,
 groups databases, and privileges. It is a small wrapper around the
-[`postgresql_user`][pguser], [`postgresql_db`][pgdb] and
-[`postgresql_privs`][pgprivs] standard modules provided with Ansible. Many
+[`postgresql_user`][pguser], [`postgresql_db`][pgdb], [`postgresql_ext`][pgext],
+and [`postgresql_privs`][pgprivs] standard modules provided with Ansible. Many
 PostgreSQL roles exist in [Ansible Galaxy][ansiblegalaxy] but none exist for
 only managing database objects without managing the server installation and
 configuration. For that, see [galaxyproject.postgresql][gxpostgresql].
@@ -15,6 +15,7 @@ configuration. For that, see [galaxyproject.postgresql][gxpostgresql].
 [ansible]: http://www.ansible.com
 [pguser]: https://docs.ansible.com/ansible/latest/collections/community/postgresql/postgresql_user_module.html
 [pgdb]: https://docs.ansible.com/ansible/latest/collections/community/postgresql/postgresql_db_module.html
+[pgext]: https://docs.ansible.com/ansible/latest/collections/community/postgresql/postgresql_ext_module.html
 [pgprivs]: https://docs.ansible.com/ansible/latest/collections/community/postgresql/postgresql_privs_module.html
 [ansiblegalaxy]: https://galaxy.ansible.com
 [gxpostgresql]: https://github.com/galaxyproject/ansible-postgresql/
@@ -64,6 +65,9 @@ Objects are configured via the following variables:
   values are either `present` (default) or `absent`).
 - `postgresql_objects_databases`: A list of databases to create or drop. List
   items are dictionaries, keys match the [`postgresql_db`][pgdb] module
+  parameters.
+- `postgresql_objects_extensions`: A list of extensions to create or drop. List
+  items are dictionaries, keys match the [`postgresql_ext`][pgext] module
   parameters.
 - `postgresql_objects_privileges`: A list of privileges to grant or revoke.
   List items are dictionaries, keys match the [`postgresql_privs`][pgprivs]

--- a/roles/postgresql_objects/defaults/main.yml
+++ b/roles/postgresql_objects/defaults/main.yml
@@ -24,4 +24,5 @@ postgresql_objects_ignore_revoke_failure: true
 postgresql_objects_users: []
 postgresql_objects_groups: []
 postgresql_objects_databases: []
+postgresql_objects_extensions: []
 postgresql_objects_privileges: []

--- a/roles/postgresql_objects/tasks/main.yml
+++ b/roles/postgresql_objects/tasks/main.yml
@@ -129,6 +129,23 @@
   loop_control:
     label: "{{ item.name }}"
 
+- name: Create and drop extensions
+  community.postgresql.postgresql_ext:
+    name: "{{ item.name }}"
+    state: "{{ item.state | default(omit) }}"
+    cascade: "{{ item.cascade | default(omit) }}"
+    comment: "{{ item.comment | default(omit) }}"
+    schema: "{{ item.schema | default(omit) }}"
+    version: "{{ item.version | default(omit) }}"
+    login_db: "{{ item.database }}"
+    login_host: "{{ postgresql_objects_login_host | default(omit) }}"
+    login_user: "{{ postgresql_objects_login_user | default(omit) }}"
+    login_password: "{{ postgresql_objects_login_password | default(omit) }}"
+    login_port: "{{ postgresql_objects_port | default(omit) }}"
+  loop: "{{ postgresql_objects_extensions }}"
+  loop_control:
+    label: "{{ item.name }}"
+
 - name: Grant extra privileges
   community.postgresql.postgresql_privs:
     roles: "{{ item.roles }}"

--- a/roles/postgresql_objects/tasks/main.yml
+++ b/roles/postgresql_objects/tasks/main.yml
@@ -23,7 +23,7 @@
     login_host: "{{ postgresql_objects_login_host | default(omit) }}"
     login_user: "{{ postgresql_objects_login_user | default(omit) }}"
     login_password: "{{ postgresql_objects_login_password | default(omit) }}"
-    port: "{{ postgresql_objects_port | default(omit) }}"
+    login_port: "{{ postgresql_objects_port | default(omit) }}"
   loop: "{{ postgresql_objects_privileges }}"
   register: revoke
   failed_when: >-
@@ -49,7 +49,7 @@
     login_host: "{{ postgresql_objects_login_host | default(omit) }}"
     login_user: "{{ postgresql_objects_login_user | default(omit) }}"
     login_password: "{{ postgresql_objects_login_password | default(omit) }}"
-    port: "{{ postgresql_objects_port | default(omit) }}"
+    login_port: "{{ postgresql_objects_port | default(omit) }}"
   loop: "{{ postgresql_objects_databases }}"
   when: (item.state | default('present')) == 'absent'
 
@@ -63,7 +63,7 @@
     login_host: "{{ postgresql_objects_login_host | default(omit) }}"
     login_user: "{{ postgresql_objects_login_user | default(omit) }}"
     login_password: "{{ postgresql_objects_login_password | default(omit) }}"
-    port: "{{ postgresql_objects_port | default(omit) }}"
+    login_port: "{{ postgresql_objects_port | default(omit) }}"
   loop: "{{ postgresql_objects_users }}"
   loop_control:
     label: "{{ item.name }}"
@@ -77,7 +77,7 @@
     login_host: "{{ postgresql_objects_login_host | default(omit) }}"
     login_user: "{{ postgresql_objects_login_user | default(omit) }}"
     login_password: "{{ postgresql_objects_login_password | default(omit) }}"
-    port: "{{ postgresql_objects_port | default(omit) }}"
+    login_port: "{{ postgresql_objects_port | default(omit) }}"
   loop: "{{ postgresql_objects_groups }}"
   when: (item.state | default('present')) == 'present'
   loop_control:
@@ -92,7 +92,7 @@
     login_host: "{{ postgresql_objects_login_host | default(omit) }}"
     login_user: "{{ postgresql_objects_login_user | default(omit) }}"
     login_password: "{{ postgresql_objects_login_password | default(omit) }}"
-    port: "{{ postgresql_objects_port | default(omit) }}"
+    login_port: "{{ postgresql_objects_port | default(omit) }}"
   loop: "{{ postgresql_objects_groups | subelements('users', skip_missing=True) }}"
   when: (item.0.state | default('present')) == 'present'
   loop_control:
@@ -105,7 +105,7 @@
     login_host: "{{ postgresql_objects_login_host | default(omit) }}"
     login_user: "{{ postgresql_objects_login_user | default(omit) }}"
     login_password: "{{ postgresql_objects_login_password | default(omit) }}"
-    port: "{{ postgresql_objects_port | default(omit) }}"
+    login_port: "{{ postgresql_objects_port | default(omit) }}"
   loop: "{{ postgresql_objects_groups }}"
   when: (item.state | default('present')) == 'absent'
   loop_control:
@@ -123,7 +123,7 @@
     login_host: "{{ postgresql_objects_login_host | default(omit) }}"
     login_user: "{{ postgresql_objects_login_user | default(omit) }}"
     login_password: "{{ postgresql_objects_login_password | default(omit) }}"
-    port: "{{ postgresql_objects_port | default(omit) }}"
+    login_port: "{{ postgresql_objects_port | default(omit) }}"
   loop: "{{ postgresql_objects_databases }}"
   when: (item.state | default('present')) == 'present'
   loop_control:
@@ -142,7 +142,7 @@
     login_host: "{{ postgresql_objects_login_host | default(omit) }}"
     login_user: "{{ postgresql_objects_login_user | default(omit) }}"
     login_password: "{{ postgresql_objects_login_password | default(omit) }}"
-    port: "{{ postgresql_objects_port | default(omit) }}"
+    login_port: "{{ postgresql_objects_port | default(omit) }}"
   loop: "{{ postgresql_objects_privileges }}"
   when: (item.state | default('present')) == 'present'
   loop_control:

--- a/roles/postgresql_objects/tasks/main.yml
+++ b/roles/postgresql_objects/tasks/main.yml
@@ -12,7 +12,6 @@
 
 - name: Revoke extra privileges
   community.postgresql.postgresql_privs:
-    database: "{{ item.database }}"
     roles: "{{ item.roles }}"
     type: "{{ item.type | default(omit) }}"
     objs: "{{ item.objs | default(omit) }}"
@@ -20,6 +19,7 @@
     schema: "{{ item.schema | default(omit) }}"
     grant_option: "{{ item.grant_option | default(omit) }}"
     state: "{{ item.state | default(omit) }}"
+    login_db: "{{ item.database }}"
     login_host: "{{ postgresql_objects_login_host | default(omit) }}"
     login_user: "{{ postgresql_objects_login_user | default(omit) }}"
     login_password: "{{ postgresql_objects_login_password | default(omit) }}"
@@ -131,7 +131,6 @@
 
 - name: Grant extra privileges
   community.postgresql.postgresql_privs:
-    database: "{{ item.database | default(omit) }}"
     roles: "{{ item.roles }}"
     type: "{{ item.type | default(omit) }}"
     objs: "{{ item.objs | default(omit) }}"
@@ -139,6 +138,7 @@
     schema: "{{ item.schema | default(omit) }}"
     grant_option: "{{ item.grant_option | default(omit) }}"
     state: "{{ item.state | default(omit) }}"
+    login_db: "{{ item.database | default(omit) }}"
     login_host: "{{ postgresql_objects_login_host | default(omit) }}"
     login_user: "{{ postgresql_objects_login_user | default(omit) }}"
     login_password: "{{ postgresql_objects_login_password | default(omit) }}"


### PR DESCRIPTION
* postgresql: fix check_mode when postgresql_version is not defined
* postgresql: allow installing extra pgsql packages
* postgresql_objects: do not use deprecated `database` param
* postgresql_objects: do not use deprecated `port` param
* postgresql_objects: add support for extensions
* Add Galaxy and Python dependencies
* Cut 1.3.0 release