### PR TITLE
Tinc revamp

### DIFF
--- a/roles/tinc/defaults/main.yml
+++ b/roles/tinc/defaults/main.yml
@@ -28,6 +28,10 @@ tinc__public_addresses: '{{ [ansible_host] }}'
 tinc__port: 655
 tinc__allow_incoming_connections: true
 
+# Lists of inventory names to connect to. Defaults to all hosts using the same
+# `tinc__netname` and with `tinc__allow_incoming_connections` set to `true`.
+tinc__connect_to: ~
+
 tinc__vpn_interface: '{{ tinc__netname }}'
 
 # IP addresses to assign to the VPN interface.
@@ -42,10 +46,13 @@ tinc__vpn_local_subnets: |-
   }}
 
 # Extra networks to export.
-tinc__vpn_extra_subnets:
+tinc__vpn_extra_subnets: []
 
 # Install ferm service configuration file.
 tinc__install_ferm_svc: false
+# Optionally limit access by a list of IP addresses/blocks. Defaults to all the
+# `tinc__public_addresses` of hosts using the same `tinc__netname`.
+tinc__ferm_allow_from: ~
 
 # Command paths.
 tinc__iproute2_path: /usr/bin/ip

--- a/roles/tinc/handlers/main.yml
+++ b/roles/tinc/handlers/main.yml
@@ -3,12 +3,12 @@
 
 - name: Reload tinc
   ansible.builtin.service:
-    name: '{{ tinc__service_name }}'
+    name: '{{ _tinc_service_name }}'
     state: reloaded
 
 - name: Restart tinc
   ansible.builtin.service:
-    name: '{{ tinc__service_name }}'
+    name: '{{ _tinc_service_name }}'
     state: restarted
 
 - name: Reload systemd

--- a/roles/tinc/tasks/remove.yml
+++ b/roles/tinc/tasks/remove.yml
@@ -4,15 +4,15 @@
 - name: Check tinc uses systemd units
   ansible.builtin.stat:
     path: /lib/systemd/system/tinc@.service
-  register: tinc__tinc_unit
+  register: _tinc_tinc_unit
 
 - name: Set fact about systemd unit
   ansible.builtin.set_fact:
-    tinc__use_systemd: '{{ tinc__tinc_unit.stat.exists }}'
+    _tinc_use_systemd: '{{ _tinc_tinc_unit.stat.exists }}'
 
 - name: Stop and disable tinc
   ansible.builtin.service:
-    name: '{{ tinc__service_name }}'
+    name: '{{ _tinc_service_name }}'
     enabled: false
     state: stopped
 
@@ -29,11 +29,11 @@
 
 - name: Delete systemd unit override
   ansible.builtin.file:
-    path: /etc/systemd/system/{{ tinc__service_name }}.service.d/override.conf
+    path: /etc/systemd/system/{{ _tinc_service_name }}.service.d/override.conf
     state: absent
   notify:
     - Reload systemd
-  when: tinc__use_systemd
+  when: _tinc_use_systemd
 
 - name: Delete local configuration copy
   ansible.builtin.file:

--- a/roles/tinc/tasks/remove.yml
+++ b/roles/tinc/tasks/remove.yml
@@ -8,8 +8,7 @@
 
 - name: Set fact about systemd unit
   ansible.builtin.set_fact:
-    tinc__use_systemd: false
-  when: not tinc__tinc_unit.stat.exists
+    tinc__use_systemd: '{{ tinc__tinc_unit.stat.exists }}'
 
 - name: Stop and disable tinc
   ansible.builtin.service:

--- a/roles/tinc/tasks/setup.yml
+++ b/roles/tinc/tasks/setup.yml
@@ -13,8 +13,7 @@
 
 - name: Set fact about systemd unit
   ansible.builtin.set_fact:
-    tinc__use_systemd: false
-  when: not tinc__tinc_unit.stat.exists
+    tinc__use_systemd: '{{ tinc__tinc_unit.stat.exists }}'
 
 - name: Set daemon parameters in /etc/default/tinc
   ansible.builtin.lineinfile:

--- a/roles/tinc/tasks/setup.yml
+++ b/roles/tinc/tasks/setup.yml
@@ -111,8 +111,7 @@
     path: /etc/tinc/{{ tinc__netname }}/hosts/{{ item }}
     state: absent
   with_items: '{{ tinc__host_files.stdout_lines }}'
-  when: >-
-    item not in tinc__hostvars or tinc__hostvars[item].tinc__remove
+  when: item not in _tinc_hosts
 
 - name: Fetch tinc hosts file after key creation
   ansible.builtin.fetch:

--- a/roles/tinc/tasks/setup.yml
+++ b/roles/tinc/tasks/setup.yml
@@ -9,11 +9,11 @@
 - name: Check tinc uses systemd units
   ansible.builtin.stat:
     path: /lib/systemd/system/tinc@.service
-  register: tinc__tinc_unit
+  register: _tinc_tinc_unit
 
 - name: Set fact about systemd unit
   ansible.builtin.set_fact:
-    tinc__use_systemd: '{{ tinc__tinc_unit.stat.exists }}'
+    _tinc_use_systemd: '{{ _tinc_tinc_unit.stat.exists }}'
 
 - name: Set daemon parameters in /etc/default/tinc
   ansible.builtin.lineinfile:
@@ -41,7 +41,7 @@
     create: true
   notify:
     - Restart tinc
-  when: not tinc__use_systemd
+  when: not _tinc_use_systemd
 
 - name: Create tinc.conf file from template
   ansible.builtin.template:
@@ -68,10 +68,10 @@
   ansible.builtin.command: >-
     awk '/^-----BEGIN RSA PUBLIC KEY-----$/,/^-----END RSA PUBLIC KEY-----$/'
     /etc/tinc/{{ tinc__netname }}/hosts/{{ inventory_hostname }}
-  register: tinc__public_key
+  register: _tinc_public_key
   changed_when: >
-    not tinc__public_key.stdout.endswith('-----END RSA PUBLIC KEY-----')
-  failed_when: tinc__public_key.rc not in (0, 1, 2)
+    not _tinc_public_key.stdout.endswith('-----END RSA PUBLIC KEY-----')
+  failed_when: _tinc_public_key.rc not in (0, 1, 2)
   check_mode: false
 
 - name: Set host parameters
@@ -88,7 +88,7 @@
   ansible.builtin.file:
     path: /etc/tinc/{{ tinc__netname }}/rsa_key.priv
     state: absent
-  when: tinc__public_key.changed
+  when: _tinc_public_key.changed
   notify:
     - Restart tinc
 
@@ -96,13 +96,13 @@
   ansible.builtin.command: tincd -n {{ tinc__netname }} -K4096
   args:
     creates: /etc/tinc/{{ tinc__netname }}/rsa_key.priv
-  when: tinc__public_key.changed
+  when: _tinc_public_key.changed
   notify:
     - Restart tinc
 
 - name: Find obsolete tinc host files
   ansible.builtin.command: ls /etc/tinc/{{ tinc__netname }}/hosts/
-  register: tinc__host_files
+  register: _tinc_host_files
   changed_when: false
   check_mode: false
 
@@ -110,7 +110,7 @@
   ansible.builtin.file:
     path: /etc/tinc/{{ tinc__netname }}/hosts/{{ item }}
     state: absent
-  with_items: '{{ tinc__host_files.stdout_lines }}'
+  with_items: '{{ _tinc_host_files.stdout_lines }}'
   when: item not in _tinc_hosts
 
 - name: Fetch tinc hosts file after key creation
@@ -143,11 +143,11 @@
     name: tinc
     enabled: true
     state: started
-  when: tinc__use_systemd
+  when: _tinc_use_systemd
 
 - name: Ensure tinc is started
   ansible.builtin.service:
-    name: '{{ tinc__service_name }}'
+    name: '{{ _tinc_service_name }}'
     enabled: true
     state: started
 

--- a/roles/tinc/templates/ferm.conf.j2
+++ b/roles/tinc/templates/ferm.conf.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 {% with -%}
-{% set saddr = _tinc_other_public_addresses %}
+{% set saddr = _tinc_ferm_allow_from %}
 {% set saddr = saddr if saddr is string else saddr | join(' ') %}
 domain (ip ip6) table filter chain INPUT {
     proto tcp

--- a/roles/tinc/templates/ferm.conf.j2
+++ b/roles/tinc/templates/ferm.conf.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 {% with -%}
-{% set saddr = tinc__other_public_addresses %}
+{% set saddr = _tinc_other_public_addresses %}
 {% set saddr = saddr if saddr is string else saddr | join(' ') %}
 domain (ip ip6) table filter chain INPUT {
     proto tcp

--- a/roles/tinc/templates/host.conf.j2
+++ b/roles/tinc/templates/host.conf.j2
@@ -7,4 +7,4 @@ Address = {{ addr }} {{ tinc__port }}
 Subnet = {{ item }}
 {% endfor %}
 
-{{ tinc__public_key.stdout }}
+{{ _tinc_public_key.stdout }}

--- a/roles/tinc/templates/host.conf.j2
+++ b/roles/tinc/templates/host.conf.j2
@@ -2,9 +2,8 @@
 {% for addr in tinc__public_addresses %}
 Address = {{ addr }} {{ tinc__port }}
 {% endfor %}
-{% for item in (
-        (tinc__vpn_local_subnets or []) + (tinc__vpn_extra_subnets or [])
-        ) %}
+{% for item in (tinc__vpn_local_subnets or []) + (tinc__vpn_extra_subnets or [])
+%}
 Subnet = {{ item }}
 {% endfor %}
 

--- a/roles/tinc/templates/tinc.conf.j2
+++ b/roles/tinc/templates/tinc.conf.j2
@@ -2,13 +2,6 @@
 Name = {{ inventory_hostname }}
 Interface = {{ tinc__vpn_interface }}
 Port = {{ tinc__port }}
-{% for host, config in tinc__hostvars | dictsort %}
-{% if inventory_hostname != host and (
-        config.tinc__allow_incoming_connections
-        if config.tinc__allow_incoming_connections is not none else True) and
-      not config.tinc__remove and
-      tinc__netname == (config.tinc__netname or tinc__netname)
-%}
+{% for host in _tinc_connect_to | sort %}
 ConnectTo = {{ host }}
-{% endif %}
 {% endfor %}

--- a/roles/tinc/vars/main.yml
+++ b/roles/tinc/vars/main.yml
@@ -4,12 +4,21 @@
 _tinc_combined_hostvars: >-
   {{ dict(hostvars) | combine(tinc__external_hosts or {}) }}
 
+_tinc_removed_hosts: >-
+  {{
+    _tinc_combined_hostvars.items() |
+    selectattr('1.tinc__remove', 'defined') |
+    selectattr('1.tinc__remove', 'false') |
+    map(attribute='0')
+  }}
+
 _tinc_hosts: >-
   {{
     _tinc_combined_hostvars.items() |
     selectattr('1.tinc__vpn_addresses', 'defined') |
     selectattr('1.tinc__vpn_addresses', 'ansible.builtin.truthy') |
-    map(attribute='0')
+    map(attribute='0') |
+    ansible.builtin.difference(_tinc_removed_hosts)
   }}
 
 tinc__hostvars: |-
@@ -32,6 +41,15 @@ tinc__hostvars: |-
   {% set ns.result = ns.result | combine({host: conf}) %}
   {% endfor %}
   {{- ns.result }}
+
+_tinc_connect_to: >-
+  {{
+    tinc__hostvars.items() |
+    selectattr('1.tinc__host', 'ne', inventory_hostname) |
+    selectattr('1.tinc__allow_incoming_connections', 'true') |
+    selectattr('1.tinc__netname', 'eq', tinc__netname) |
+    map(attribute='0')
+  }}
 
 tinc__other_public_addresses: >-
   {{

--- a/roles/tinc/vars/main.yml
+++ b/roles/tinc/vars/main.yml
@@ -1,24 +1,38 @@
 # vim:ts=2:sw=2:et:ai:sts=2
 ---
-# TODO: fix line length and remove disable/enable
-# yamllint disable rule:line-length
-tinc__hostvars: >-
-  {{ dict(hostvars) | combine(tinc__external_hosts) | dict2items | json_query(
-  '[?value.tinc__vpn_addresses].{
-    "key": key,
-    "value": {
-      "tinc__host": key,
-      "tinc__public_addresses": value.tinc__public_addresses || [value.ansible_host],
-      "tinc__vpn_addresses": value.tinc__vpn_addresses,
-      "tinc__allow_incoming_connections": value.tinc__allow_incoming_connections,
-      "tinc__remove": value.tinc__remove,
-      "tinc__netname": value.tinc__netname
-      }
-    }
-  ') | items2dict
+
+_tinc_combined_hostvars: >-
+  {{ dict(hostvars) | combine(tinc__external_hosts or {}) }}
+
+_tinc_hosts: >-
+  {{
+    _tinc_combined_hostvars.items() |
+    selectattr('1.tinc__vpn_addresses', 'defined') |
+    selectattr('1.tinc__vpn_addresses', 'ansible.builtin.truthy') |
+    map(attribute='0')
   }}
 
-# yamllint enable rule:line-length
+tinc__hostvars: |-
+  {% set ns = namespace(result={}) %}
+  {% for host in _tinc_hosts %}
+  {% set hvars = _tinc_combined_hostvars[host] %}
+  {% set conf = {
+    'tinc__host': host,
+    'tinc__public_addresses':
+      hvars.get('tinc__public_addresses', [hvars.ansible_host]) or [],
+    'tinc__vpn_addresses':
+      hvars.get('tinc__vpn_addresses'),
+    'tinc__allow_incoming_connections':
+      hvars.get('tinc__allow_incoming_connections', True) | bool,
+    'tinc__remove':
+      hvars.get('tinc__remove', False) | bool,
+    'tinc__netname':
+      hvars.get('tinc__netname', 'tinc'),
+  } %}
+  {% set ns.result = ns.result | combine({host: conf}) %}
+  {% endfor %}
+  {{- ns.result }}
+
 tinc__other_public_addresses: >-
   {{
     tinc__hostvars.values() |

--- a/roles/tinc/vars/main.yml
+++ b/roles/tinc/vars/main.yml
@@ -46,14 +46,16 @@ _tinc_connect_to: >-
     map(attribute='0')
   }}
 
-_tinc_other_public_addresses: >-
+_tinc_ferm_allow_from: >-
   {{
     _tinc_hostvars.items() |
     selectattr('0', 'ne', inventory_hostname) |
     selectattr('1.tinc__public_addresses', 'defined') |
+    selectattr('1.tinc__public_addresses', 'ansible.builtin.truthy') |
+    selectattr('1.tinc__netname', 'eq', tinc__netname) |
     map(attribute='1.tinc__public_addresses') |
-    sort |
-    sum(start=[])
+    sum(start=[]) |
+    sort
    }}
 
 _tinc_service_name: >-

--- a/roles/tinc/vars/main.yml
+++ b/roles/tinc/vars/main.yml
@@ -43,7 +43,5 @@ tinc__other_public_addresses: >-
     sum(start=[])
    }}
 
-tinc__use_systemd: >-
-  {{ (ansible_service_mgr | d()) == "systemd" }}
 tinc__service_name: >-
   {{ "tinc@" + tinc__netname if tinc__use_systemd else "tinc" }}

--- a/roles/tinc/vars/main.yml
+++ b/roles/tinc/vars/main.yml
@@ -26,15 +26,10 @@ tinc__hostvars: |-
   {% for host in _tinc_hosts %}
   {% set hvars = _tinc_combined_hostvars[host] %}
   {% set conf = {
-    'tinc__host': host,
     'tinc__public_addresses':
       hvars.get('tinc__public_addresses', [hvars.ansible_host]) or [],
-    'tinc__vpn_addresses':
-      hvars.get('tinc__vpn_addresses'),
     'tinc__allow_incoming_connections':
       hvars.get('tinc__allow_incoming_connections', True) | bool,
-    'tinc__remove':
-      hvars.get('tinc__remove', False) | bool,
     'tinc__netname':
       hvars.get('tinc__netname', 'tinc'),
   } %}
@@ -45,7 +40,7 @@ tinc__hostvars: |-
 _tinc_connect_to: >-
   {{
     tinc__hostvars.items() |
-    selectattr('1.tinc__host', 'ne', inventory_hostname) |
+    selectattr('0', 'ne', inventory_hostname) |
     selectattr('1.tinc__allow_incoming_connections', 'true') |
     selectattr('1.tinc__netname', 'eq', tinc__netname) |
     map(attribute='0')
@@ -54,9 +49,9 @@ _tinc_connect_to: >-
 tinc__other_public_addresses: >-
   {{
     tinc__hostvars.values() |
-    selectattr('tinc__host', 'ne', inventory_hostname) |
-    selectattr('tinc__public_addresses', 'defined') |
-    map(attribute='tinc__public_addresses') |
+    selectattr('0', 'ne', inventory_hostname) |
+    selectattr('1.tinc__public_addresses', 'defined') |
+    map(attribute='1.tinc__public_addresses') |
     sort |
     sum(start=[])
    }}

--- a/roles/tinc/vars/main.yml
+++ b/roles/tinc/vars/main.yml
@@ -37,7 +37,7 @@ _tinc_hostvars: |-
   {% endfor %}
   {{- ns.result }}
 
-_tinc_connect_to: >-
+_tinc_connect_to_auto: >-
   {{
     _tinc_hostvars.items() |
     selectattr('0', 'ne', inventory_hostname) |
@@ -46,7 +46,10 @@ _tinc_connect_to: >-
     map(attribute='0')
   }}
 
-_tinc_ferm_allow_from: >-
+_tinc_connect_to: >-
+  {{ tinc__connect_to or _tinc_connect_to_auto }}
+
+_tinc_ferm_allow_from_auto: >-
   {{
     _tinc_hostvars.items() |
     selectattr('0', 'ne', inventory_hostname) |
@@ -57,6 +60,9 @@ _tinc_ferm_allow_from: >-
     sum(start=[]) |
     sort
    }}
+
+_tinc_ferm_allow_from: >-
+  {{ tinc__ferm_allow_from or _tinc_ferm_allow_from_auto }}
 
 _tinc_service_name: >-
   {{ "tinc@" + tinc__netname if _tinc_use_systemd else "tinc" }}

--- a/roles/tinc/vars/main.yml
+++ b/roles/tinc/vars/main.yml
@@ -21,7 +21,7 @@ _tinc_hosts: >-
     ansible.builtin.difference(_tinc_removed_hosts)
   }}
 
-tinc__hostvars: |-
+_tinc_hostvars: |-
   {% set ns = namespace(result={}) %}
   {% for host in _tinc_hosts %}
   {% set hvars = _tinc_combined_hostvars[host] %}
@@ -39,16 +39,16 @@ tinc__hostvars: |-
 
 _tinc_connect_to: >-
   {{
-    tinc__hostvars.items() |
+    _tinc_hostvars.items() |
     selectattr('0', 'ne', inventory_hostname) |
     selectattr('1.tinc__allow_incoming_connections', 'true') |
     selectattr('1.tinc__netname', 'eq', tinc__netname) |
     map(attribute='0')
   }}
 
-tinc__other_public_addresses: >-
+_tinc_other_public_addresses: >-
   {{
-    tinc__hostvars.values() |
+    _tinc_hostvars.items() |
     selectattr('0', 'ne', inventory_hostname) |
     selectattr('1.tinc__public_addresses', 'defined') |
     map(attribute='1.tinc__public_addresses') |
@@ -56,5 +56,5 @@ tinc__other_public_addresses: >-
     sum(start=[])
    }}
 
-tinc__service_name: >-
-  {{ "tinc@" + tinc__netname if tinc__use_systemd else "tinc" }}
+_tinc_service_name: >-
+  {{ "tinc@" + tinc__netname if _tinc_use_systemd else "tinc" }}


### PR DESCRIPTION
A collection of much-needed improvements to the `tinc` role:

* tinc: replace `json_query` with pure Jinja2
  The JMESPath code is very difficult to read, this commit replaces it with a 
  slightly less hacky implementation.
* tinc: remove unneeded dependency on ansible facts
* tinc: move complex logic to vars/
* tinc: clean-up vars/
* tinc: fix names of private variables
* tinc: improve selection of addresses for ferm
* tinc: add variables to override automatic defaults
  Add `tinc__connect_to` and `tinc__ferm_allow_from` variables to allow
  override the defaults computed from other hosts' configurations.